### PR TITLE
Add m/s, ft/s, and kts to Speed extension

### DIFF
--- a/CommunityExtensions/Speed/Speed.js
+++ b/CommunityExtensions/Speed/Speed.js
@@ -1,15 +1,39 @@
 numi.addUnit({
     "id": "kmh",
-    "phrases": "kmh, kmph, km/h, khm",
+    "phrases": "kmh, kmph, khm, kph, klicks, kilometers per hour",
     "baseUnitId": "second",
-    "format": "kmh",
+    "format": "km/h",
     "ratio": 1
 });
 
 numi.addUnit({
     "id": "mph",
-    "phrases": "mph, MPH, miles per hour",
+    "phrases": "mph, miles per hour",
     "baseUnitId": "second",
     "format": "mph",
     "ratio": 1.609344
+});
+
+numi.addUnit({
+    "id": "meterspersecond",
+    "phrases": "mps, meters per second",
+    "baseUnitId": "second",
+    "format": "m/s",
+    "ratio": 3.6
+});
+
+numi.addUnit({
+    "id": "feetpersecond", // allow for "frames per second" elsewhere
+    "phrases": "fps, ftps, ft per sec, ft per second, feet per second",
+    "baseUnitId": "second",
+    "format": "ft/s",
+    "ratio": 1.097
+});
+
+numi.addUnit({
+    "id": "knots",
+    "phrases": "kts, knots",
+    "baseUnitId": "second",
+    "format": "kt",
+    "ratio": 1.852
 });


### PR DESCRIPTION
Also cleaned up the phrases and formats for MPH and KM/H: phrases cannot
have slashes, and formats are more standard.

Per wikipedia:

![image](https://user-images.githubusercontent.com/1566363/61012787-aeee7200-a334-11e9-94bc-7946aa845300.png)

In Numi:

![image](https://user-images.githubusercontent.com/1566363/61012774-954d2a80-a334-11e9-9000-81f7f1bc1e84.png)

Thanks for the cool tool, saw it mentioned as an alternative to Soulver on https://news.ycombinator.com/item?id=20403270 today.

